### PR TITLE
Update home page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ Keep this to a minimum and always consider if it belongs in .rubocop_common.yml 
 
 ## Development
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/klarna/rubocop_rules.
+Bug reports and pull requests are welcome on GitHub at https://github.com/klippx/rubocop_rules.


### PR DESCRIPTION
It's a bit confusing that 2 repositories exist for this project. This one seems to be the most up-to-date, except this URL which is still pointing to the other repository.

I hope this helps un-confuse the situation 😊 (maybe deleting the other repository or adding an explicit message about why there are two different repositories would be even better...)